### PR TITLE
fix readme option of ParseSwagger

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,16 @@
-parse-server-swagger
-====================
+# parse-server-swagger
 
 [V1 ROADMAP](https://github.com/bhtz/parse-server-swagger/wiki/Roadmap)
 
 Autogenerate parse server API swagger.json and swagger UI from Parse Server schemas.
 
-Installation
-------------
+## Installation
 
         npm i parse-server-swagger -S
 
-How to use ?
-------------
+## How to use ?
 
-``` js
+```js
 
 var ParseSwagger = require('parse-server-swagger');
 
@@ -21,7 +18,7 @@ var ParseSwagger = require('parse-server-swagger');
 if (CONFIG.swagger) {
     var parseSwagger = new ParseSwagger({
         host: 'http:localhost:1337',
-        parsePath: '/parse'
+        apiRoot: '/parse'
         appId: '<appId>',
         masterKey: '<masterKey>',
     });
@@ -31,10 +28,10 @@ if (CONFIG.swagger) {
 
 ```
 
-Expose swagger UI here: 
-    
-    '/swagger'
+Expose swagger UI here:
+  
+ '/swagger'
 
 Expose swagger.json here:
-    
-    '/api-docs'
+  
+ '/api-docs'


### PR DESCRIPTION
Line 29 of index.js : `url: this.config.host + this.config.apiRoot + '/schemas',`

`apiRoot` is use instead of `parsePath`